### PR TITLE
Add custom prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ import noteworthy.botkit as botkit
 import noteworthy.botkit.response as response
 import noteworthy.botkit.cache as cache
 
-@botkit.botkit_controller(bot_name='dicebot')
+@botkit.botkit_controller(bot_name='dicebot', bot_prefix='!dice')
 class DiceBotController():
 
     AUTH = botkit.auth.PublicBot
@@ -93,13 +93,13 @@ bot.run()
 
 Accepts all invites and responds to all users. Produces dice rolls in `<N>d<S>` format with:
 
-    !dicebot roll <number_of_dice>d<number_of_sides>
+    !dice roll <number_of_dice>d<number_of_sides>
 
 ## Decorators
 
 ### botkit_controller
 
-Requires specifying a `bot_name` - bots are invoked by writing `!<bot_name> <method>` in chat. Marks a python class as a bot controller. Adds `create_matrix_bot` class method that takes in `creds` and creates a bot. The bot's `run` starts the bot and blocks while the bot is running.
+Requires specifying a `bot_name` - bots are invoked by writing `<bot_prefix> <method>` in chat. The `bot_prefix` is `!<bot_name>` by default, but can be specified otherwise. Marks a python class as a bot controller. Adds `create_matrix_bot` class method that takes in `creds` and creates a bot. The bot's `run` starts the bot and blocks while the bot is running.
 
 #### creds
 
@@ -107,7 +107,7 @@ Requires specifying a `bot_name` - bots are invoked by writing `!<bot_name> <met
 
 ### botkit_method
 
-Marks a function as a bot method. Can be invoked with `!<bot_name> <function_name>`
+Marks a function as a bot method. Can be invoked with `<bot_prefix> <function_name>`
 
 #### cache_result
 

--- a/noteworthy/botkit/bot.py
+++ b/noteworthy/botkit/bot.py
@@ -25,8 +25,12 @@ class Bot():
             self.CACHE = controller.CACHE
         else:
             self.CACHE = NoCache()
+        
 
     def _setup_handlers(self, controller):
+        self.prefix = controller.BOTKIT_BOT_PREFIX
+        if not self.prefix:
+          self.prefix = "!" + self.name
         self.commands = {}
         self.msg_handler = None
         self.startup_method = None
@@ -34,7 +38,7 @@ class Bot():
         for member in members:
             if hasattr(member[1], 'botkit_method'):
                 # add member[1]
-                command_str = f'!{self.name} {member[0]}'
+                command_str = f'{self.prefix} {member[0]}'
                 self.commands[command_str] = member[1]
             elif hasattr(member[1], 'botkit_msg_handler'):
                 if self.msg_handler:
@@ -119,6 +123,7 @@ class Bot():
         return msg
 
     async def loginandsync(self):
+        print("loginandsync")
         await self.client.login(self.password)
         if self.startup_method:
             await self.startup_method(self.client)

--- a/noteworthy/botkit/decorators.py
+++ b/noteworthy/botkit/decorators.py
@@ -34,7 +34,7 @@ def botkit_startup_method(func):
     return wrapped
 
 
-def botkit_controller(bot_name, channel_greeting=None):
+def botkit_controller(bot_name, channel_greeting=None, bot_prefix=None):
     '''Marks a class to generate a matrix bot.
        Marked class will get a create_matrix_bot method that will create a Bot instance.
     '''
@@ -43,6 +43,7 @@ def botkit_controller(bot_name, channel_greeting=None):
         cls.botkit_controller = True
         cls.BOTKIT_BOT_NAME = bot_name
         cls.CHANNEL_GREETING = channel_greeting
+        cls.BOTKIT_BOT_PREFIX = bot_prefix
 
         @staticmethod
         def create_matrix_bot(creds):


### PR DESCRIPTION
Fulfills [decentralabs/noteworthy-botkit#2](https://github.com/decentralabs/noteworthy-botkit/issues/2)
Allows the user to specify custom prefix instead of being forced to use the bot name as a prefix.